### PR TITLE
Fix setup.py and associated metadata

### DIFF
--- a/semaphore/__init__.py
+++ b/semaphore/__init__.py
@@ -17,10 +17,8 @@
 # You should have received a copy of the GNU Lesser Public License
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 """Semaphore: A simple (rule-based) bot library for Signal Private Messenger."""
-__author__ = 'Lazlo Westerhof'
-__email__ = 'semaphore@lazlo.me'
-__license__ = 'GPLv3'
-__version__ = '0.6.0'
+
+from .meta import *
 
 from .attachment import Attachment
 from .bot import Bot

--- a/semaphore/meta.py
+++ b/semaphore/meta.py
@@ -1,0 +1,6 @@
+"""Semaphore: A simple (rule-based) bot library for Signal Private Messenger."""
+
+__author__ = 'Lazlo Westerhof'
+__email__ = 'semaphore@lazlo.me'
+__license__ = 'AGPLv3+'
+__version__ = '0.6.0'

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,21 @@
 #!/usr/bin/env python
+import importlib
+import importlib.util
+from pathlib import Path
 from setuptools import find_packages, setup
 
-from semaphore import __author__, __email__, __license__, __version__
+
+def import_by_path(module_name, path):
+    """Import the module name and not its parent package.
+    Return the module.
+    """
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+meta = import_by_path('meta', Path(__file__).parent / 'semaphore' / 'meta.py')
 
 # Get the long description from the README file
 with open("README.md", "r") as fh:
@@ -15,22 +29,25 @@ requirements = [
 
 setup(
     name="semaphore",
-    version=__version__,
-    author=__author__,
-    author_email=__email__,
+    version=meta.__version__,
+    author=meta.__author__,
+    author_email=meta.__email__,
     description=(
         "Semaphore: A simple (rule-based) bot library for Signal Private Messenger."
     ),
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/lwesterhof/semaphore",
-    license=__license__,
+    license=meta.__license__,
     packages=find_packages(),
     install_requires=requirements,
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)',
+        (
+            'License :: OSI Approved :: '
+            'GNU Affero General Public License v3 or later (AGPLv3+)'
+        ),
         'Operating System :: OS Independent',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Communications :: Chat',


### PR DESCRIPTION
`__version__` and such cannot be imported from semaphore until its required
dependencies are imported, which creates a bootstrapping problem for setup.py.
Fix this issue by moving the metadata to a separate module and directly importing that module.
Also update some inconsistent license metadata.