### PR TITLE
Make interaction with the message a side effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,10 @@ Do not send anything confidential, use at your own risk!
 
 ## Code example
 ```python
-from semaphore import Bot, ChatContext, Reply
+from semaphore import Bot, ChatContext
 
-def echo(context: ChatContext) -> Reply:
-    return Reply(body=context.message.get_body())
+def echo(context: ChatContext) -> None:
+    context.message.reply(body=context.message.get_body())
 
 def main():
     """Start the bot."""

--- a/examples/apodbot.py
+++ b/examples/apodbot.py
@@ -25,10 +25,12 @@ from pathlib import Path
 import feedparser  # type: ignore
 from bs4 import BeautifulSoup  # type: ignore
 
-from semaphore import Bot, ChatContext, Reply
+from semaphore import Bot, ChatContext
 
 
-def apod(context: ChatContext) -> Reply:
+def apod(context: ChatContext) -> None:
+    context.message.mark_read()
+
     path = Path(__file__).parent.absolute()
     Feed = feedparser.parse('https://apod.nasa.gov/apod.rss')
     pointer = Feed.entries[0]
@@ -45,7 +47,7 @@ def apod(context: ChatContext) -> Reply:
                   "width": "100",
                   "height": "100"}
 
-    return Reply(body=message, attachments=[attachment])
+    context.message.reply(body=message, attachments=[attachment])
 
 
 def main():

--- a/examples/bbcbot.py
+++ b/examples/bbcbot.py
@@ -23,10 +23,11 @@ import re
 
 import feedparser  # type: ignore
 
-from semaphore import Bot, ChatContext, Reply
+from semaphore import Bot, ChatContext
 
 
-def bbc_info(context: ChatContext) -> Reply:
+def bbc_info(context: ChatContext) -> None:
+    context.message.mark_read()
     info = """BBC News Bot
 
 !bbc world    - BBC World news
@@ -34,10 +35,10 @@ def bbc_info(context: ChatContext) -> Reply:
 !bbc politics - BBC Politics news
 !bbc tech     - BBC Technology news"""
 
-    return Reply(body=info)
+    context.message.reply(body=info)
 
 
-def bbc_feed(context: ChatContext) -> Reply:
+def bbc_feed(context: ChatContext):
     # Find out which news feed to parse.
     try:
         news = context.match.group(1)
@@ -65,7 +66,7 @@ def bbc_feed(context: ChatContext) -> Reply:
         if x < 2:
             reply += "\n\n"
 
-    return Reply(body=reply)
+    context.message.reply(body=reply)
 
 
 def main():

--- a/examples/btcbot.py
+++ b/examples/btcbot.py
@@ -26,10 +26,10 @@ import urllib.request
 from time import time
 from typing import Optional
 
-from semaphore import Bot, ChatContext, Reply
+from semaphore import Bot, ChatContext
 
 
-def check_price(context: ChatContext) -> Optional[Reply]:
+def check_price(context: ChatContext) -> None:
     url = "https://blockchain.info/ticker"
     request = urllib.request.Request(url)
 
@@ -45,11 +45,10 @@ def check_price(context: ChatContext) -> Optional[Reply]:
             old_job.schedule_removal()
 
         notification = f"BTC price dropped below ${price}!\nCurrent price: ${last_price}"
-        return Reply(body=notification)
-    return None
+        context.message.reply(body=notification)
 
 
-def set_notification(context: ChatContext) -> Reply:
+def set_notification(context: ChatContext) -> None:
     try:
         now = time()
         price = int(context.match.group(1))
@@ -60,17 +59,20 @@ def set_notification(context: ChatContext) -> Reply:
         job = context.job_queue.run_repeating(now, check_price, context, 5 * 60)
         context.data["job"] = job
 
-        return Reply(body="BTC price check set!")
+        context.message.mark_read()
+        context.message.reply(body="BTC price check set!")
     except Exception:
-        return Reply(body="Usage: !btc <dollars>")
+        context.message.mark_read()
+        context.message.reply(body="Usage: !btc <dollars>")
 
 
-def unset_notification(context: ChatContext) -> Reply:
+def unset_notification(context: ChatContext) -> None:
     if 'job' in context.data:
         old_job = context.data["job"]
         old_job.schedule_removal()
 
-    return Reply(body="BTC price check unset!")
+    context.message.mark_read()
+    context.message.reply(body="BTC price check unset!")
 
 
 def main():

--- a/examples/echobot.py
+++ b/examples/echobot.py
@@ -22,8 +22,9 @@ Signal Bot example, repeats received messages.
 from semaphore import Bot, ChatContext, Reply
 
 
-def echo(context: ChatContext) -> Reply:
-    return Reply(body=context.message.get_body())
+def echo(context: ChatContext) -> None:
+    context.message.mark_read()
+    context.message.reply(body=context.message.get_body())
 
 
 def main():

--- a/examples/lovebot.py
+++ b/examples/lovebot.py
@@ -19,11 +19,12 @@
 """
 Signal Bot example, loves everything you say!
 """
-from semaphore import Bot, ChatContext, Reply
+from semaphore import Bot, ChatContext
 
 
-def love(context: ChatContext) -> Reply:
-    return Reply(body="❤️", reaction=True, stop=False)
+def love(context: ChatContext) -> None:
+    context.message.mark_read()
+    context.message.reply(body="❤️", reaction=True, stop=False)
 
 
 def main():

--- a/examples/quotebot.py
+++ b/examples/quotebot.py
@@ -19,11 +19,12 @@
 """
 Signal Bot example, quotes and repeats the received messages.
 """
-from semaphore import Bot, ChatContext, Reply
+from semaphore import Bot, ChatContext
 
 
-def quote(context: ChatContext) -> Reply:
-    return Reply(body=context.message.get_body(), quote=True)
+def quote(context: ChatContext) -> None:
+    context.message.mark_read()
+    context.message.reply(body=context.message.get_body(), quote=True)
 
 
 def main():

--- a/examples/spongebot.py
+++ b/examples/spongebot.py
@@ -19,10 +19,10 @@
 """
 Signal Bot example, repeats received messages in sPOngEbOb sqUArepAnTs text.
 """
-from semaphore import Bot, ChatContext, Reply
+from semaphore import Bot, ChatContext
 
 
-def spongebob(context: ChatContext) -> Reply:
+def spongebob(context: ChatContext) -> None:
     from random import random
     from random import seed
 
@@ -33,9 +33,8 @@ def spongebob(context: ChatContext) -> Reply:
         case_choice = random() < 0.5
         spongecase.append(ch.upper() if (case_choice) else ch.lower())
 
-    return Reply(
-        body=''.join(spongecase)
-    )
+    context.message.mark_read()
+    context.message.reply(body=''.join(spongecase))
 
 
 def main():

--- a/examples/timerbot.py
+++ b/examples/timerbot.py
@@ -22,14 +22,14 @@ Signal Bot example, sends an alert after a specified time.
 import re
 from time import time
 
-from semaphore import Bot, ChatContext, Reply
+from semaphore import Bot, ChatContext
 
 
-def alarm(context: ChatContext) -> Reply:
-    return Reply(body="Beep! Beep! Beep!")
+def alarm(context: ChatContext) -> None:
+    context.message.reply(body="Beep! Beep! Beep!")
 
 
-def set_timer(context: ChatContext) -> Reply:
+def set_timer(context: ChatContext) -> None:
     try:
         delta = int(context.match.group(1))
         alarm_time = time() + delta
@@ -41,17 +41,20 @@ def set_timer(context: ChatContext) -> Reply:
         job = context.job_queue.run_once(alarm_time, alarm, context)
         context.data["job"] = job
 
-        return Reply(body="Timer set!")
+        context.message.mark_read()
+        context.message.reply(body="Timer set!")
     except Exception:
-        return Reply(body="'Usage: !timer <seconds>'")
+        context.message.mark_read()
+        context.message.reply(body="'Usage: !timer <seconds>'")
 
 
-def unset_timer(context: ChatContext) -> Reply:
+def unset_timer(context: ChatContext) -> None:
     if 'job' in context.data:
         old_job = context.data["job"]
         old_job.schedule_removal()
 
-    return Reply(body="Timer unset!")
+    context.message.mark_read()
+    context.message.reply(body="Timer unset!")
 
 
 def main():

--- a/examples/xkcdbot.py
+++ b/examples/xkcdbot.py
@@ -25,10 +25,12 @@ from pathlib import Path
 import feedparser  # type: ignore
 from bs4 import BeautifulSoup  # type: ignore
 
-from semaphore import Bot, ChatContext, Reply
+from semaphore import Bot, ChatContext
 
 
-def xkcd(context: ChatContext) -> Reply:
+def xkcd(context: ChatContext) -> None:
+    context.message.mark_read()
+
     path = Path(__file__).parent.absolute()
     Feed = feedparser.parse('https://xkcd.com/rss.xml')
     pointer = Feed.entries[0]
@@ -45,7 +47,7 @@ def xkcd(context: ChatContext) -> Reply:
                   "width": "100",
                   "height": "100"}
 
-    return Reply(body=message, attachments=[attachment])
+    context.message.reply(body=message, attachments=[attachment])
 
 
 def main():

--- a/semaphore/reply.py
+++ b/semaphore/reply.py
@@ -28,4 +28,3 @@ class Reply:
     attachments: list = attr.ib(default=[])
     quote: bool = attr.ib(default=False)
     reaction: bool = attr.ib(default=False)
-    stop: bool = attr.ib(default=True)

--- a/semaphore/socket.py
+++ b/semaphore/socket.py
@@ -40,7 +40,7 @@ class Socket:
         self._socket.connect(self._socket_path)
         self.log.info(f"Connected to socket ({self._socket_path})")
         self.send({"type": "subscribe", "username": self._username})
-        self.log.info(f"Bot subscribed (+********{self._username[-3:]})")
+        self.log.info(f"Bot attempted to subscribe to +********{self._username[-3:]}")
 
     def read(self) -> Iterator[bytes]:
         """Read a socket, line by line."""


### PR DESCRIPTION
The library currently requires that message handlers return a value
in order to react to the message. This is not ideal for two reasons:

1)	Handlers cannot do multiple things with the message,
	such as replying twice, reacting and then replying, etc.
2)	Handlers cannot reply immediately and then continue processing.

I have changed the API from returning a Reply object to passing the args
for the Reply constructor to message.reply(). Additionally, I have made
marking the message as read optional, as some bots may not want to send
read receipts, or may only want to send them when the response is done.

Additionally, I have cleaned up some logging statements.
Messages that are really only useful for debugging were moved from INFO
to DEBUG, error logs were moved to ERROR,
and tracebacks were added using the `exc_info` kwarg when necessary.
The log statements that were moved to DEBUG would have spammed logs 
for a hypothetical popular bot.

Sorry I did the logging in the same PR but it was kinda hard to separate
and I needed these improvements in order to debug my changes.