### PR TITLE
relax anyio requirement to be compatible with asks

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Build package
         run: |
-          python -m pip install -r requirements.txt
+          python -m pip install .
           python setup.py sdist bdist_wheel
 
       - name: Install package

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-attrs==18.2.0
-attr==0.3.1
-python_dateutil==2.8.1

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 requirements = [
-    'anyio>=2.0.2,<3.0.0',
+    'anyio<3.0.0',
     'attrs==18.2.0',
     'attr==0.3.1',
     'python_dateutil==2.8.1',


### PR DESCRIPTION
apparently asks currently requires anyio<2 still.
once the latest asks commits are tagged and release we can go back to requiring anyio 2.0