### PR TITLE
Fix repeating job re-add to queue

### DIFF
--- a/semaphore/job_queue.py
+++ b/semaphore/job_queue.py
@@ -118,5 +118,5 @@ class JobQueue:
 
             if job.is_repeating():
                 interval = job.get_interval()
-                await self._queue.put(now + interval, job)
+                await self._queue.put_nowait(now + interval, job)
                 self.log.info(f"Added repeating job ({id(job)}) to the queue")


### PR DESCRIPTION
If a job is repeating, the job is re-added to the queue after each iteration. The method called was `put` which `PriorityQueue` doesn't implement.

Use the correct `put_nowait`.