### PR TITLE
Add send_message method to Bot

### DIFF
--- a/examples/newsletter_bot.py
+++ b/examples/newsletter_bot.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+#
+# Semaphore: A simple (rule-based) bot library for Signal Private Messenger.
+# Copyright (C) 2020 Lazlo Westerhof <semaphore@lazlo.me>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+Signal Bot example, repeats received messages.
+"""
+import os
+from typing import List
+
+from semaphore import Bot, ChatContext
+
+
+async def echo(ctx: ChatContext) -> None:
+    if not ctx.message.empty():
+        await ctx.message.typing_started()
+        await ctx.message.reply(ctx.message.get_body())
+        await ctx.message.typing_stopped()
+
+
+class NewsletterBot:
+    bot: Bot
+    subscribers: List[str] = []
+
+    def __init__(self, bot: Bot):
+        self.bot = bot
+
+        bot.register_handler("!subscribe", self.subscribeHandler)
+        bot.register_handler("!sendToAll", self.sendHandler)
+
+    async def subscribeHandler(self, ctx: ChatContext) -> None:
+        self.subscribers.append(ctx.message.source)
+        await ctx.message.reply("Subscription successful!")
+
+    async def sendHandler(self, ctx: ChatContext) -> None:
+        # Send messages to all subscribers without using ChatContext
+        for subscriber in self.subscribers:
+            await self.bot.send_message(subscriber, ctx.message.get_body()[len("!sendToAll"):].strip())
+
+    async def start(self) -> None:
+        # Run the bot until you press Ctrl-C.
+        await self.bot.start()
+
+
+async def main():
+    """Start the bot."""
+    # Connect the bot to number.
+    async with Bot(os.environ["SIGNAL_PHONE_NUMBER"]) as bot:
+        await NewsletterBot(bot).start()
+
+
+if __name__ == '__main__':
+    import anyio
+
+    anyio.run(main)

--- a/examples/newsletter_bot.py
+++ b/examples/newsletter_bot.py
@@ -24,13 +24,6 @@ from typing import List
 from semaphore import Bot, ChatContext
 
 
-async def echo(ctx: ChatContext) -> None:
-    if not ctx.message.empty():
-        await ctx.message.typing_started()
-        await ctx.message.reply(ctx.message.get_body())
-        await ctx.message.typing_stopped()
-
-
 class NewsletterBot:
     bot: Bot
     subscribers: List[str] = []

--- a/examples/newsletter_bot.py
+++ b/examples/newsletter_bot.py
@@ -39,9 +39,11 @@ class NewsletterBot:
         await ctx.message.reply("Subscription successful!")
 
     async def sendHandler(self, ctx: ChatContext) -> None:
-        # Send messages to all subscribers without using ChatContext
+        message = ctx.message.get_body()[len("!sendToAll"):].strip()
+
+        # Send message to all subscribers without using ChatContext
         for subscriber in self.subscribers:
-            await self.bot.send_message(subscriber, ctx.message.get_body()[len("!sendToAll"):].strip())
+            await self.bot.send_message(subscriber, message)
 
     async def start(self) -> None:
         # Run the bot until you press Ctrl-C.

--- a/semaphore/bot.py
+++ b/semaphore/bot.py
@@ -153,3 +153,6 @@ class Bot:
             async for message in self._receiver.receive():
                 if message.data_message is not None:
                     await tg.spawn(self._match_message, message)
+
+    async def send_message(self, receiver, body, attachments=None) -> None:
+        await self._sender.send_message(receiver, body, attachments)

--- a/semaphore/job_queue.py
+++ b/semaphore/job_queue.py
@@ -108,7 +108,7 @@ class JobQueue:
             try:
                 reply = await job.run()
                 if reply:
-                    await self._sender.send_message(message, reply)
+                    await self._sender.reply_message(message, reply)
                     self.log.info(f"Reply for job ({id(job)}) sent to {message.source}")
             except StopPropagation:
                 continue

--- a/semaphore/message.py
+++ b/semaphore/message.py
@@ -80,7 +80,7 @@ class Message:
         :param *args:    The body of the reply
         :param **kwargs: Keyword arguments of the Reply constructor
         """
-        await self._sender.send_message(self, Reply(*args, **kwargs))
+        await self._sender.reply_message(self, Reply(*args, **kwargs))
 
     async def typing_started(self) -> None:
         """Send a typing started message."""

--- a/semaphore/message_sender.py
+++ b/semaphore/message_sender.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """This module contains a class that handles sending bot messages."""
+import re
 from typing import Any, Dict
 
 from .message import Message
@@ -34,7 +35,25 @@ class MessageSender:
     async def _send(self, message: Dict) -> None:
         await self._socket.send(message)
 
-    async def send_message(self, message: Message, reply: Reply) -> None:
+    async def send_message(self, receiver, body, attachments=None):
+        bot_message = {
+            "type": "send",
+            "username": self._username,
+            "messageBody": body
+        }
+
+        if re.search("\+\d*", receiver):
+            bot_message["recipientAddress"] = {"number": receiver}
+        else:
+            bot_message["recipientAddress"] = {"uuid": receiver}
+
+        # Add attachments to message.
+        if attachments:
+            bot_message["attachments"] = attachments
+
+        await self._send(bot_message)
+
+    async def reply_message(self, message: Message, reply: Reply) -> None:
         """
         Send the bot message.
 

--- a/semaphore/message_sender.py
+++ b/semaphore/message_sender.py
@@ -42,7 +42,7 @@ class MessageSender:
             "messageBody": body
         }
 
-        if re.search("\+\d*", receiver):
+        if re.search(r"\+\d*", receiver):
             bot_message["recipientAddress"] = {"number": receiver}
         else:
             bot_message["recipientAddress"] = {"uuid": receiver}


### PR DESCRIPTION
Solves #21. 

I renamed  `MessageSender.send_message` to `reply_message` and introduced a `send_message` method to send a message without replying to an existing one. One can use the Phone Number or UUID to send a message.

I do not know if `Bot` is the best class for `send_message`, because this way you can just use it inside handlers if you store the bot instance, such as in the new newsletter example.