### PR TITLE
Add ablity to use own error handler for Bot

### DIFF
--- a/examples/exceptionbot.py
+++ b/examples/exceptionbot.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+#
+# Semaphore: A simple (rule-based) bot library for Signal Private Messenger.
+# Copyright (C) 2020 Lazlo Westerhof <semaphore@lazlo.me>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+Signal Bot example, repeats received messages.
+"""
+import logging
+import os
+
+from semaphore import Bot, ChatContext
+
+
+async def raise_exception(ctx: ChatContext) -> None:
+    raise Exception("Please handle me")
+
+
+async def exception_handler(exception: Exception, context: ChatContext):
+    logging.error(f"An exception was caught: {exception}. The message received was "
+                  f"{context.message.get_body()}")
+
+
+async def main():
+    """Start the bot."""
+    # Connect the bot to number.
+    async with Bot(os.environ["SIGNAL_PHONE_NUMBER"]) as bot:
+        bot.register_handler("", raise_exception)
+        bot.set_exception_handler(exception_handler)
+
+        # Run the bot until you press Ctrl-C.
+        await bot.start()
+
+
+if __name__ == '__main__':
+    import anyio
+
+    anyio.run(main)


### PR DESCRIPTION
This PR is related to #23 and adds a method to Bot to add a user-defined `Callable[[Exception, ChatContext], Awaitable[None]` method for exception handling. This enables the user to add its own logic for exception handling.