### PR TITLE
Add option to wait for signald.send() confirmation

### DIFF
--- a/examples/broadcastbot.py
+++ b/examples/broadcastbot.py
@@ -55,7 +55,11 @@ async def broadcast(ctx: ChatContext) -> None:
 
     # Broadcast message to all subscribers.
     for subscriber in subscribers:
-        await ctx.bot.send_message(subscriber, message)
+        if await ctx.bot.send_message(subscriber, message):
+            print(f"Message successfully sent to {subscriber}")
+        else:
+            print(f"Could not send message to {subscriber}")
+            del subscribers[subscriber]
 
 
 async def main():

--- a/semaphore/bot.py
+++ b/semaphore/bot.py
@@ -49,6 +49,8 @@ class Bot:
         self._socket_path: str = socket_path
         self._receiver: MessageReceiver
         self._sender: MessageSender
+        self._receive_socket: Optional[Socket] = None
+        self._send_socket: Optional[Socket] = None
         self._job_queue: JobQueue
         self._handlers: List = []
         self._chat_context: Dict[str, ChatContext] = {}
@@ -61,8 +63,6 @@ class Bot:
             level=logging_level
         )
         self.log = logging.getLogger(__name__)
-
-        self._socket: Socket
 
     def register_handler(self, regex: Pattern, func: Callable) -> None:
         """Register a chat handler with a regex."""
@@ -147,19 +147,25 @@ class Bot:
 
     async def __aenter__(self) -> 'Bot':
         """Connect to the bot's internal socket."""
-        self._socket = await Socket(self._username,
-                                    self._socket_path).__aenter__()
-        self._sender = MessageSender(self._username, self._socket)
+        self._send_socket = await Socket(self._username,
+                                         self._socket_path,
+                                         False).__aenter__()
+        self._sender = MessageSender(self._username, self._send_socket)
         return self
 
     async def __aexit__(self, *excinfo):
         """Disconnect from the bot's internal socket."""
-        return await self._socket.__aexit__(*excinfo)
+        if self._receive_socket:
+            await self._receive_socket.__aexit__(*excinfo)
+        await self._send_socket.__aexit__(*excinfo)
 
     async def start(self) -> None:
         """Start the bot event loop."""
         self.log.info("Bot started")
-        self._receiver = MessageReceiver(self._socket, self._sender)
+        self._receive_socket = await Socket(self._username,
+                                            self._socket_path,
+                                            True).__aenter__()
+        self._receiver = MessageReceiver(self._receive_socket, self._sender)
 
         if self._profile_name:
             await self.set_profile(self._profile_name, self._profile_picture)
@@ -173,15 +179,16 @@ class Bot:
                 if message.data_message is not None:
                     await tg.spawn(self._match_message, message)
 
-    async def send_message(self, receiver, body, attachments=None) -> None:
+    async def send_message(self, receiver, body, attachments=None) -> bool:
         """
         Send a message.
 
         :param receiver:    The receiver of the message (uuid or number).
         :param body:        The body of the message.
         :param attachments: Optional attachments to the message.
+        :@return successful: Whether sending message was successful
         """
-        await self._sender.send_message(receiver, body, attachments)
+        return await self._sender.send_message(receiver, body, attachments)
 
     async def set_profile(self, profile_name: str, profile_avatar: str = None) -> None:
         """

--- a/semaphore/bot.py
+++ b/semaphore/bot.py
@@ -186,7 +186,8 @@ class Bot:
         :param receiver:    The receiver of the message (uuid or number).
         :param body:        The body of the message.
         :param attachments: Optional attachments to the message.
-        :@return successful: Whether sending message was successful
+        :return: Returns whether sending is successful
+        :rtype: bool
         """
         return await self._sender.send_message(receiver, body, attachments)
 

--- a/semaphore/message_sender.py
+++ b/semaphore/message_sender.py
@@ -66,7 +66,7 @@ class MessageSender:
             bot_message["attachments"] = attachments
 
         self.signald_message_id += 1
-        bot_message['id'] = self.signald_message_id
+        bot_message['id'] = str(self.signald_message_id)
 
         await self._send(bot_message)
 

--- a/semaphore/message_sender.py
+++ b/semaphore/message_sender.py
@@ -82,7 +82,8 @@ class MessageSender:
                 continue
 
             # Skip everything but response for our message
-            if 'id' not in response_wrapper or response_wrapper['id'] != bot_message['id']:
+            if ('id' not in response_wrapper or
+                    response_wrapper['id'] != bot_message['id']):
                 continue
 
             if response_wrapper.get("error"):

--- a/semaphore/message_sender.py
+++ b/semaphore/message_sender.py
@@ -28,6 +28,7 @@ from .socket import Socket
 
 class MessageSender:
     """This class handles sending bot messages."""
+    signald_message_id: int = 0
 
     def __init__(self, username: str, socket: Socket):
         """Initialize message sender."""
@@ -64,6 +65,9 @@ class MessageSender:
         if attachments:
             bot_message["attachments"] = attachments
 
+        self.signald_message_id += 1
+        bot_message['id'] = self.signald_message_id
+
         await self._send(bot_message)
 
         # Wait for success response
@@ -77,7 +81,7 @@ class MessageSender:
                 continue
 
             # Skip everything but response for our message
-            if response_wrapper['type'] != "send":
+            if 'id' not in response_wrapper or response_wrapper['id'] != bot_message['id']:
                 continue
 
             if response_wrapper.get("error"):

--- a/semaphore/message_sender.py
+++ b/semaphore/message_sender.py
@@ -45,6 +45,8 @@ class MessageSender:
         :param receiver:    The receiver of the message (uuid or number).
         :param body:        The body of the message.
         :param attachments: Optional attachments to the message.
+        :return: Returns whether sending is successful
+        :rtype: bool
         """
         bot_message = {
             "type": "send",
@@ -79,7 +81,8 @@ class MessageSender:
                 continue
 
             if response_wrapper.get("error"):
-                self.log.warning(f"Could not send message to {receiver}: {response_wrapper['error'].get('message')}")
+                self.log.warning(f"Could not send message to {receiver}:"
+                                 f"{response_wrapper['error'].get('message')}")
                 return False
 
             response = response_wrapper['data']
@@ -88,7 +91,8 @@ class MessageSender:
                 continue
 
             for result in results:
-                if result['address'].get('uuid') == receiver or result['address'].get('number') == receiver:
+                if result['address'].get('uuid') == receiver or \
+                        result['address'].get('number') == receiver:
                     if result.get('success'):
                         return True
                     return False

--- a/semaphore/message_sender.py
+++ b/semaphore/message_sender.py
@@ -82,8 +82,10 @@ class MessageSender:
                 continue
 
             # Skip everything but response for our message
-            if ('id' not in response_wrapper
-                    or response_wrapper['id'] != bot_message['id']):
+            if 'id' not in response_wrapper:
+                continue
+
+            if response_wrapper['id'] != bot_message['id']:
                 continue
 
             if response_wrapper.get("error"):

--- a/semaphore/message_sender.py
+++ b/semaphore/message_sender.py
@@ -77,7 +77,8 @@ class MessageSender:
             # Load Signal message wrapper
             try:
                 response_wrapper = json.loads(line)
-            except json.JSONDecodeError:
+            except json.JSONDecodeError as e:
+                self.log.error("Could not decode signald response", exc_info=e)
                 continue
 
             # Skip everything but response for our message
@@ -92,7 +93,7 @@ class MessageSender:
             response = response_wrapper['data']
             results = response.get("results")
             if not results:
-                continue
+                return False
 
             for result in results:
                 if result['address'].get('uuid') == receiver or \

--- a/semaphore/message_sender.py
+++ b/semaphore/message_sender.py
@@ -82,8 +82,8 @@ class MessageSender:
                 continue
 
             # Skip everything but response for our message
-            if ('id' not in response_wrapper or
-                    response_wrapper['id'] != bot_message['id']):
+            if ('id' not in response_wrapper
+                    or response_wrapper['id'] != bot_message['id']):
                 continue
 
             if response_wrapper.get("error"):

--- a/semaphore/socket.py
+++ b/semaphore/socket.py
@@ -29,11 +29,13 @@ class Socket:
 
     def __init__(self,
                  username: str,
-                 socket_path: str = "/var/run/signald/signald.sock"):
+                 socket_path: str = "/var/run/signald/signald.sock",
+                 subscribe: bool = False):
         """Initialize socket."""
         self._username: str = username
         self._socket_path: str = socket_path
         self._socket: anyio.abc.SocketStream
+        self._subscribe: bool = subscribe
 
         self.log = logging.getLogger(__name__)
 
@@ -41,8 +43,10 @@ class Socket:
         """Connect to the socket."""
         self._socket = await (await anyio.connect_unix(self._socket_path)).__aenter__()
         self.log.info(f"Connected to socket ({self._socket_path})")
-        await self.send({"type": "subscribe", "username": self._username})
-        self.log.info(f"Bot attempted to subscribe to +********{self._username[-3:]}")
+
+        if self._subscribe:
+            await self.send({"type": "subscribe", "username": self._username})
+            self.log.info(f"Bot attempted to subscribe to +********{self._username[-3:]}")
         return self
 
     async def __aexit__(self, *excinfo):


### PR DESCRIPTION
Resolves #28 

I use 2 different sockets for now, so we do not interfere with receiving messages if waiting for a response to our send message. This PR makes `send_message -> bool` and logs warnings if a message could not be sent.

We could also add this for `reply_message` or do you think this is not really necessary?