### PR TITLE
Bugfix: Use first working signald socket

### DIFF
--- a/semaphore/socket.py
+++ b/semaphore/socket.py
@@ -50,6 +50,7 @@ class Socket:
             try:
                 self._socket = await (await anyio.connect_unix(sockets[i])).__aenter__()
                 self.log.info(f"Connected to socket ({sockets[i]})")
+                break
             except FileNotFoundError:
                 if i:
                     self.log.debug(


### PR DESCRIPTION
The current version does not work (for me), because it tries different socket locations, despite the first one is valid. I guess there is a break missing.