### PR TITLE
Add option to throw Signald Errors on send

### DIFF
--- a/semaphore/bot.py
+++ b/semaphore/bot.py
@@ -43,7 +43,8 @@ class Bot:
                  profile_emoji=None,
                  profile_about=None,
                  logging_level=logging.INFO,
-                 socket_path=None):
+                 socket_path=None,
+                 raise_errors=False):
         """Initialize bot."""
         self._username: str = username
         self._profile_name: str = profile_name
@@ -60,6 +61,7 @@ class Bot:
         self._chat_context: Dict[str, ChatContext] = {}
         self._exception_handler: Optional[Callable[[Exception, ChatContext],
                                                    Awaitable[None]]]
+        self._raise_errors = raise_errors
 
         threading.current_thread().name = 'bot'
         logging.basicConfig(
@@ -152,7 +154,8 @@ class Bot:
         self._send_socket = await Socket(self._username,
                                          self._socket_path,
                                          False).__aenter__()
-        self._sender = MessageSender(self._username, self._send_socket)
+        self._sender = MessageSender(self._username, self._send_socket,
+                                     self._raise_errors)
         return self
 
     async def __aexit__(self, *excinfo):

--- a/semaphore/exceptions.py
+++ b/semaphore/exceptions.py
@@ -16,7 +16,99 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """This module contains exceptions for Semaphore."""
+from typing import List
 
 
 class StopPropagation(Exception):
     """Raise this to prevent further handlers from running on this message."""
+
+
+class SignaldError(Exception):
+    """This is the base class for Signald Errors"""
+    IDENTIFIER: str
+    pass
+
+
+class NoSuchAccountError(SignaldError):
+    IDENTIFIER = "NoSuchAccountError"
+
+    account: str
+    message: str
+
+
+class SeverNotFoundError(SignaldError):
+    IDENTIFIER = "SeverNotFoundError"
+
+    message: str
+    uuid: str
+
+
+class InvalidProxyError(SignaldError):
+    IDENTIFIER = "InvalidProxyError"
+
+    message: str
+
+
+class NoSendPermissionError(SignaldError):
+    IDENTIFIER = "NoSendPermissionError"
+
+    message: str
+
+
+class InvalidAttachmentError(SignaldError):
+    IDENTIFIER = "InvalidAttachmentError"
+
+    filename: str
+    message: str
+
+
+class InternalError(SignaldError):
+    IDENTIFIER = "InternalError"
+
+    exceptions: List[str]
+    message: str
+
+
+class IllegalArgumentException(SignaldError):
+    IDENTIFIER = "IllegalArgumentException"
+
+    message: str
+    stackTraceDepth: int
+
+
+class InvalidRequestError(SignaldError):
+    IDENTIFIER = "InvalidRequestError"
+
+    message: str
+
+
+class UnknownGroupError(SignaldError):
+    IDENTIFIER = "UnknownGroupError"
+
+    message: str
+
+
+class RateLimitError(SignaldError):
+    IDENTIFIER = "RateLimitError"
+
+    message: str
+
+
+class InvalidRecipientError(SignaldError):
+    IDENTIFIER = "InvalidRecipientError"
+
+    message: str
+
+
+class UnknownError(SignaldError):
+    """Exception raised if send did return an error that is
+    not implemented in semaphore"""
+
+    def __init__(self, error_object):
+        self.error_object = error_object
+
+
+SIGNALD_ERRORS = [NoSuchAccountError, SeverNotFoundError, InvalidProxyError,
+                  NoSendPermissionError, InvalidAttachmentError, InternalError,
+                  IllegalArgumentException, InvalidRequestError, UnknownGroupError,
+                  RateLimitError, InvalidRecipientError]

--- a/semaphore/exceptions.py
+++ b/semaphore/exceptions.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """This module contains exceptions for Semaphore."""
-from typing import List, Dict, Optional
+from typing import Dict, List, Optional
 
 
 class StopPropagation(Exception):

--- a/semaphore/exceptions.py
+++ b/semaphore/exceptions.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """This module contains exceptions for Semaphore."""
-from typing import List
+from typing import List, Dict, Optional
 
 
 class StopPropagation(Exception):
@@ -25,7 +25,6 @@ class StopPropagation(Exception):
 
 class SignaldError(Exception):
     """This is the base class for Signald Errors"""
-    IDENTIFIER: str
     pass
 
 
@@ -103,12 +102,16 @@ class InvalidRecipientError(SignaldError):
 class UnknownError(SignaldError):
     """Exception raised if send did return an error that is
     not implemented in semaphore"""
+    error: Optional[Dict]
+    error_type: str
 
-    def __init__(self, error_object):
-        self.error_object = error_object
+    def __init__(self, error_type: str, error_object: Optional[Dict]):
+        self.error_type = error_type
+        self.error = error_object
 
 
-SIGNALD_ERRORS = [NoSuchAccountError, SeverNotFoundError, InvalidProxyError,
-                  NoSendPermissionError, InvalidAttachmentError, InternalError,
-                  IllegalArgumentException, InvalidRequestError, UnknownGroupError,
-                  RateLimitError, InvalidRecipientError]
+IDENTIFIABLE_SIGNALD_ERRORS = [NoSuchAccountError, SeverNotFoundError, InvalidProxyError,
+                               NoSendPermissionError, InvalidAttachmentError,
+                               InternalError, IllegalArgumentException,
+                               InvalidRequestError, UnknownGroupError, RateLimitError,
+                               InvalidRecipientError]

--- a/semaphore/exceptions.py
+++ b/semaphore/exceptions.py
@@ -25,6 +25,8 @@ class StopPropagation(Exception):
 
 class SignaldError(Exception):
     """This is the base class for Signald Errors"""
+    IDENTIFIER: str
+
     pass
 
 

--- a/semaphore/message_sender.py
+++ b/semaphore/message_sender.py
@@ -22,7 +22,7 @@ import logging
 import re
 from typing import Any, Dict
 
-from .exceptions import UnknownError, SIGNALD_ERRORS
+from .exceptions import SIGNALD_ERRORS, UnknownError
 from .message import Message
 from .reply import Reply
 from .socket import Socket

--- a/semaphore/message_sender.py
+++ b/semaphore/message_sender.py
@@ -22,7 +22,7 @@ import logging
 import re
 from typing import Any, Dict
 
-from .exceptions import SIGNALD_ERRORS, UnknownError
+from .exceptions import IDENTIFIABLE_SIGNALD_ERRORS, UnknownError
 from .message import Message
 from .reply import Reply
 from .socket import Socket
@@ -79,7 +79,7 @@ class MessageSender:
                         return False
 
                     # Match error
-                    for error_class in SIGNALD_ERRORS:
+                    for error_class in IDENTIFIABLE_SIGNALD_ERRORS:
                         if error_class.IDENTIFIER == response_wrapper.get("error_type"):
                             error_dict = response_wrapper.get("error")
                             if not error_dict:
@@ -91,7 +91,8 @@ class MessageSender:
 
                             raise error
 
-                    raise UnknownError(response_wrapper.get("error"))
+                    raise UnknownError(response_wrapper.get("error_type"),
+                                       response_wrapper.get("error"))
 
                 response = response_wrapper['data']
                 results = response.get("results")

--- a/semaphore/message_sender.py
+++ b/semaphore/message_sender.py
@@ -32,10 +32,11 @@ class MessageSender:
     """This class handles sending bot messages."""
     signald_message_id: int = 0
 
-    def __init__(self, username: str, socket: Socket):
+    def __init__(self, username: str, socket: Socket, raise_errors: bool = False):
         """Initialize message sender."""
         self._username: str = username
         self._socket: Socket = socket
+        self._raise_signald_errors = raise_errors
         self._socket_lock = asyncio.Lock()
         self.log = logging.getLogger(__name__)
 
@@ -73,6 +74,10 @@ class MessageSender:
                 if response_wrapper.get("error") is not None:
                     self.log.warning(f"Could not send message:"
                                      f"{response_wrapper}")
+
+                    if not self._raise_signald_errors:
+                        return False
+
                     # Match error
                     for error_class in SIGNALD_ERRORS:
                         if error_class.IDENTIFIER == response_wrapper.get("error_type"):


### PR DESCRIPTION
This PR adds an option (default False), so that Signald Errors described [here](https://docs.signald.org/protocol/actions/v1/send/) are raised. The default option is False, so the current behaviour is not changed, and the several `send` methods return False.

If the option is set, e.g. `message.reply` may throw an `RateLimitError` or other errors described in `exceptions.py`.

Motivation: My current project with currently ~800 daily Users of a Signal Bot sometimes runs into RateLimit Errors, but we can't distinguish these from e.g. deleted accounts or similar. This PR changes that.