### PR TITLE
Upgrade remaining requests to v1

### DIFF
--- a/semaphore/message.py
+++ b/semaphore/message.py
@@ -36,11 +36,9 @@ class Message:
     source: Address
     envelope_type: int
     timestamp: int
-    timestamp_iso: str
     server_timestamp: int
     _sender: 'MessageSender'
     source_device: int = attr.ib(default=0)
-    uuid: str = attr.ib(default=None)
     relay: str = attr.ib(default=None)
     has_legacy_message: bool = attr.ib(default=False)
     has_content: bool = attr.ib(default=False)

--- a/semaphore/message.py
+++ b/semaphore/message.py
@@ -42,7 +42,6 @@ class Message:
     relay: str = attr.ib(default=None)
     has_legacy_message: bool = attr.ib(default=False)
     has_content: bool = attr.ib(default=False)
-    is_receipt: bool = attr.ib(default=False)
     data_message: Optional[DataMessage] = attr.ib(default=None)
     is_unidentified_sender: bool = attr.ib(default=False)
 

--- a/semaphore/message_receiver.py
+++ b/semaphore/message_receiver.py
@@ -64,13 +64,13 @@ class MessageReceiver:
                 raise ValueError("Signald: listen stopped")
 
             # Only handle messages.
-            if message_wrapper["type"] != "message":
+            if message_wrapper["type"] != "IncomingMessage":
                 continue
 
             try:
                 message = message_wrapper["data"]
                 data_message: Optional[DataMessage] = None
-                data = message.get("dataMessage")
+                data = message.get("data_message")
                 if data:
                     group: Optional[Group] = None
                     groupV2: Optional[GroupV2] = None
@@ -118,21 +118,19 @@ class MessageReceiver:
                     )
 
                 yield Message(
-                    username=message["username"],
+                    username=message["account"],
                     source=Address(
                         uuid=message["source"].get("uuid"),
                         number=message["source"].get("number"),
                     ),
                     envelope_type=message["type"],
                     timestamp=message["timestamp"],
-                    timestamp_iso=message["timestampISO"],
-                    server_timestamp=message["serverDeliveredTimestamp"],
-                    source_device=message.get("sourceDevice"),
-                    uuid=message.get("uuid"),
+                    server_timestamp=message["server_receiver_timestamp"],
+                    source_device=message.get("source_device"),
                     relay=message.get("relay"),
-                    has_legacy_message=message.get("hasLegacyMessage"),
-                    is_receipt=message.get("isReceipt"),
-                    is_unidentified_sender=message.get("isUnidentifiedSender"),
+                    has_legacy_message=message.get("has_legacy_message"),
+                    is_unidentified_sender=message.get("unidentified_sender"),
+                    is_receipt=message.get("type") is "RECEIPT",
                     data_message=data_message,
                     sender=self._sender,
                 )

--- a/semaphore/message_receiver.py
+++ b/semaphore/message_receiver.py
@@ -133,7 +133,6 @@ class MessageReceiver:
                     relay=message.get("relay"),
                     has_legacy_message=message.get("has_legacy_message"),
                     is_unidentified_sender=message.get("unidentified_sender"),
-                    is_receipt=message.get("type") is "RECEIPT",
                     data_message=data_message,
                     sender=self._sender,
                 )

--- a/semaphore/message_receiver.py
+++ b/semaphore/message_receiver.py
@@ -59,9 +59,12 @@ class MessageReceiver:
                 self.log.warning(f"Signald an exception for: {message_wrapper}")
 
             # Handle listen_stopped
-            if message_wrapper["type"] == "listen_stopped":
-                self.log.warning(f"Signald won't deliver new messages: {message_wrapper}")
-                raise ValueError("Signald: listen stopped")
+            if message_wrapper["type"] == "ListenerState":
+                data = message_wrapper.get("data")
+                if data and not data.get("connected"):
+                    self.log.warning(f"Signald won't deliver new messages: "
+                                     f"{message_wrapper}")
+                    raise ValueError("Signald: listen stopped")
 
             # Only handle messages.
             if message_wrapper["type"] != "IncomingMessage":

--- a/semaphore/socket.py
+++ b/semaphore/socket.py
@@ -61,14 +61,14 @@ class Socket:
                     raise ConnectionError("Could not connect to socket")
 
         if self._subscribe:
-            await self.send({"type": "subscribe", "username": self._username,
+            await self.send({"type": "subscribe", "account": self._username,
                              "version": "v1"})
             self.log.info(f"Bot attempted to subscribe to +********{self._username[-3:]}")
         return self
 
     async def __aexit__(self, *excinfo):
         """Disconnect from the internal socket."""
-        await self.send({"type": "unsubscribe", "username": self._username,
+        await self.send({"type": "unsubscribe", "account": self._username,
                          "version": "v1"})
         self.log.info(f"Bot attempted to unsubscribe to +********{self._username[-3:]}")
         return await self._socket.__aexit__(*excinfo)

--- a/semaphore/socket.py
+++ b/semaphore/socket.py
@@ -61,13 +61,15 @@ class Socket:
                     raise ConnectionError("Could not connect to socket")
 
         if self._subscribe:
-            await self.send({"type": "subscribe", "username": self._username})
+            await self.send({"type": "subscribe", "username": self._username,
+                             "version": "v1"})
             self.log.info(f"Bot attempted to subscribe to +********{self._username[-3:]}")
         return self
 
     async def __aexit__(self, *excinfo):
         """Disconnect from the internal socket."""
-        await self.send({"type": "unsubscribe", "username": self._username})
+        await self.send({"type": "unsubscribe", "username": self._username,
+                         "version": "v1"})
         self.log.info(f"Bot attempted to unsubscribe to +********{self._username[-3:]}")
         return await self._socket.__aexit__(*excinfo)
 


### PR DESCRIPTION
We should migrate all communication to v1:

> All functionality of v0 protocol is available in v1. Existing clients are encouraged to update, as the v0 protocol is going away at the end of 2021
> https://docs.signald.org/articles/protocol/versioning/

When migrating (un)subscribe, we also receive the new message format. I am not sure, if I catched everything and would appreciate feedback. I currently run this PR in production, and could not yet find any missing stuff (implemented in my bot).