### PR TITLE
Use version range for attrs requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open("README.md", "r") as fh:
 
 requirements = [
     'anyio<3.0.0',
-    'attrs==18.2.0',
+    'attrs>=18.2.0,<=21.2.0',
     'python_dateutil==2.8.1',
 ]
 


### PR DESCRIPTION
These versions do not have any backward-incompatible changes relevant for us, and it makes semaphore more flexible. Lately, I encountered this error:

```
The conflict is caused by:
    semaphore-bot 0.11.0 depends on attrs==18.2.0
    aiohttp 3.8.1 depends on attrs>=17.3.0
    aiohttp-socks 0.6.1 depends on attrs>=19.2.0
    semaphore-bot 0.11.0 depends on attrs==18.2.0
    aiohttp 3.8.1 depends on attrs>=17.3.0
    aiohttp-socks 0.6.0 depends on attrs>=19.2.0
```

Which is resolved by that.