### PR TITLE
Use Attachment class to send and receive messages

### DIFF
--- a/examples/apodbot.py
+++ b/examples/apodbot.py
@@ -26,7 +26,7 @@ import asks  # type: ignore
 import feedparser  # type: ignore
 from bs4 import BeautifulSoup  # type: ignore
 
-from semaphore import Bot, ChatContext
+from semaphore import Bot, ChatContext, Attachment
 
 
 async def apod(ctx: ChatContext) -> None:
@@ -46,9 +46,7 @@ async def apod(ctx: ChatContext) -> None:
             await f.write(chunk)
 
     message = f"{pointer.title} - {description} (https://apod.nasa.gov/apod/)"
-    attachment = {"filename": str(path),
-                  "width": "100",
-                  "height": "100"}
+    attachment = Attachment(str(path), width=100, height=100)
 
     await ctx.message.reply(body=message, attachments=[attachment])
 

--- a/examples/apodbot.py
+++ b/examples/apodbot.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 # Semaphore: A simple (rule-based) bot library for Signal Private Messenger.
-# Copyright (C) 2020 Lazlo Westerhof <semaphore@lazlo.me>
+# Copyright (C) 2020-2022 Lazlo Westerhof <semaphore@lazlo.me>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -26,7 +26,7 @@ import asks  # type: ignore
 import feedparser  # type: ignore
 from bs4 import BeautifulSoup  # type: ignore
 
-from semaphore import Bot, ChatContext, Attachment
+from semaphore import Attachment, Bot, ChatContext
 
 
 async def apod(ctx: ChatContext) -> None:

--- a/examples/xkcdbot.py
+++ b/examples/xkcdbot.py
@@ -26,7 +26,7 @@ import asks  # type: ignore
 import feedparser  # type: ignore
 from bs4 import BeautifulSoup  # type: ignore
 
-from signalblast.semaphore import Bot, ChatContext, Attachment
+from semaphore import Bot, ChatContext, Attachment
 
 
 async def xkcd(ctx: ChatContext) -> None:

--- a/examples/xkcdbot.py
+++ b/examples/xkcdbot.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 # Semaphore: A simple (rule-based) bot library for Signal Private Messenger.
-# Copyright (C) 2020 Lazlo Westerhof <semaphore@lazlo.me>
+# Copyright (C) 2020-2022 Lazlo Westerhof <semaphore@lazlo.me>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -26,7 +26,7 @@ import asks  # type: ignore
 import feedparser  # type: ignore
 from bs4 import BeautifulSoup  # type: ignore
 
-from semaphore import Bot, ChatContext, Attachment
+from semaphore import Attachment, Bot, ChatContext
 
 
 async def xkcd(ctx: ChatContext) -> None:

--- a/examples/xkcdbot.py
+++ b/examples/xkcdbot.py
@@ -26,7 +26,7 @@ import asks  # type: ignore
 import feedparser  # type: ignore
 from bs4 import BeautifulSoup  # type: ignore
 
-from semaphore import Bot, ChatContext
+from signalblast.semaphore import Bot, ChatContext, Attachment
 
 
 async def xkcd(ctx: ChatContext) -> None:
@@ -46,9 +46,7 @@ async def xkcd(ctx: ChatContext) -> None:
             await f.write(chunk)
 
     message = f"{pointer.title} - {description} ({pointer.link})"
-    attachment = {"filename": str(path),
-                  "width": "100",
-                  "height": "100"}
+    attachment = Attachment(str(path), width=100, height=100)
 
     await ctx.message.reply(body=message, attachments=[attachment])
 

--- a/semaphore/attachment.py
+++ b/semaphore/attachment.py
@@ -17,7 +17,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """This module contains an object that represents a Signal message attachment."""
 import attr
-
+import re
 
 @attr.s(auto_attribs=True, frozen=True)
 class Attachment:
@@ -27,5 +27,21 @@ class Attachment:
     id: str
     size: int
     stored_filename: str
+    custom_filename: str = attr.ib(default=None)
     width: int = attr.ib(default=0)
     height: int = attr.ib(default=0)
+
+    @staticmethod
+    def _snake_to_camel(attr_name: str):
+        attr_name = re.sub(r"(_|-)+", " ", attr_name).title().replace(" ", "")
+        return ''.join([attr_name[0].lower(), attr_name[1:]])
+
+    def to_send_dict(self):
+        snake_dict_attachment = attr.asdict(self)
+        camel_dict_attachment = {}
+        for key, value in snake_dict_attachment.items():
+            camel_dict_attachment[self._snake_to_camel(key)] = value
+
+        camel_dict_attachment["filename"] = self.stored_filename
+
+        return camel_dict_attachment

--- a/semaphore/attachment.py
+++ b/semaphore/attachment.py
@@ -67,7 +67,7 @@ class Attachment:
     def create_from_receive_dict(data: dict) -> 'Attachment':
         log = logging.getLogger(__name__)
 
-        attachment = Attachment(None)
+        attachment = Attachment("")
         attachment_attr_names = attr.asdict(attachment)
 
         processed_data_attrs = set()

--- a/semaphore/attachment.py
+++ b/semaphore/attachment.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 # Semaphore: A simple (rule-based) bot library for Signal Private Messenger.
-# Copyright (C) 2020 Lazlo Westerhof <semaphore@lazlo.me>
+# Copyright (C) 2020-2022 Lazlo Westerhof <semaphore@lazlo.me>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -17,14 +17,17 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """This module contains an object that represents a Signal message attachment."""
 from __future__ import annotations
-import attr
+
 import logging
 import re
+
+import attr
 
 
 @attr.s(auto_attribs=True)
 class Attachment:
     """This object represents a Signal message attachment.
+
     The attributes have a 1 to 1 correspondance to the signald JsonAttachment class
     https://signald.org/protocol/structures/v1/JsonAttachment/
     """
@@ -38,7 +41,7 @@ class Attachment:
     height: int = attr.ib(default=None)
     id: str = attr.ib(default=None)
     key: str = attr.ib(default=None)
-    stored_filename:  str = attr.ib(default=None)
+    stored_filename: str = attr.ib(default=None)
     size: int = attr.ib(default=None)
     voice_note: bool = attr.ib(default=None)
     width: int = attr.ib(default=None)
@@ -57,7 +60,7 @@ class Attachment:
 
         if self.filename is None:
             if self.stored_filename is None:
-                raise ValueError("filename or stored_filename must be provided, found None")
+                raise ValueError("Filename or stored_filename must be provided.")
             send_data["filename"] = self.stored_filename
 
         return send_data

--- a/semaphore/attachment.py
+++ b/semaphore/attachment.py
@@ -22,7 +22,6 @@ import logging
 import re
 
 
-
 @attr.s(auto_attribs=True)
 class Attachment:
     """This object represents a Signal message attachment.

--- a/semaphore/attachment.py
+++ b/semaphore/attachment.py
@@ -16,32 +16,68 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """This module contains an object that represents a Signal message attachment."""
+from __future__ import annotations
 import attr
+import logging
 import re
 
-@attr.s(auto_attribs=True, frozen=True)
-class Attachment:
-    """This object represents a Signal message attachment."""
 
-    content_type: str
-    id: str
-    size: int
-    stored_filename: str
+
+@attr.s(auto_attribs=True)
+class Attachment:
+    """This object represents a Signal message attachment.
+    The attributes have a 1 to 1 correspondance to the signald JsonAttachment class
+    https://signald.org/protocol/structures/v1/JsonAttachment/
+    """
+
+    filename: str = attr.ib()
+    blurhash: str = attr.ib(default=None)
+    caption: str = attr.ib(default=None)
+    content_type: str = attr.ib(default=None)
     custom_filename: str = attr.ib(default=None)
-    width: int = attr.ib(default=0)
-    height: int = attr.ib(default=0)
+    digest: str = attr.ib(default=None)
+    height: int = attr.ib(default=None)
+    id: str = attr.ib(default=None)
+    key: str = attr.ib(default=None)
+    stored_filename:  str = attr.ib(default=None)
+    size: int = attr.ib(default=None)
+    voice_note: bool = attr.ib(default=None)
+    width: int = attr.ib(default=None)
 
     @staticmethod
-    def _snake_to_camel(attr_name: str):
+    def _snake_to_camel(attr_name: str) -> str:
         attr_name = re.sub(r"(_|-)+", " ", attr_name).title().replace(" ", "")
         return ''.join([attr_name[0].lower(), attr_name[1:]])
 
-    def to_send_dict(self):
-        snake_dict_attachment = attr.asdict(self)
-        camel_dict_attachment = {}
-        for key, value in snake_dict_attachment.items():
-            camel_dict_attachment[self._snake_to_camel(key)] = value
+    def to_send_dict(self) -> dict:
+        attachment_data = attr.asdict(self)
+        send_data = {}
+        for attr_name, value in attachment_data.items():
+            if value is not None and attr_name != 'stored_filename':
+                send_data[self._snake_to_camel(attr_name)] = value
 
-        camel_dict_attachment["filename"] = self.stored_filename
+        if self.filename is None:
+            if self.stored_filename is None:
+                raise ValueError("filename or stored_filename must be provided, found None")
+            send_data["filename"] = self.stored_filename
 
-        return camel_dict_attachment
+        return send_data
+
+    @staticmethod
+    def create_from_receive_dict(data: dict) -> Attachment:
+        log = logging.getLogger(__name__)
+
+        attachment = Attachment(None)
+        attachment_attr_names = attr.asdict(attachment)
+
+        processed_data_attrs = set()
+        for attr_name in attachment_attr_names:
+            data_name = Attachment._snake_to_camel(attr_name)
+            setattr(attachment, attr_name, data.get(data_name))
+            processed_data_attrs.add(data_name)
+
+        for attr_name in data:
+            if attr_name not in processed_data_attrs:
+                log.warning(f"Attribute {attr_name} in data was ignored")
+
+        return attachment

--- a/semaphore/attachment.py
+++ b/semaphore/attachment.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """This module contains an object that represents a Signal message attachment."""
-from __future__ import annotations
-
 import logging
 import re
 
@@ -66,7 +64,7 @@ class Attachment:
         return send_data
 
     @staticmethod
-    def create_from_receive_dict(data: dict) -> Attachment:
+    def create_from_receive_dict(data: dict) -> 'Attachment':
         log = logging.getLogger(__name__)
 
         attachment = Attachment(None)

--- a/semaphore/message_receiver.py
+++ b/semaphore/message_receiver.py
@@ -110,6 +110,7 @@ class MessageReceiver:
                                 id=attachment["id"],
                                 size=attachment["size"],
                                 stored_filename=attachment["storedFilename"],
+                                custom_filename=attachment["customFilename"],
                                 width=attachment["width"],
                                 height=attachment["height"],
                             )

--- a/semaphore/message_receiver.py
+++ b/semaphore/message_receiver.py
@@ -105,15 +105,7 @@ class MessageReceiver:
                         body=data.get("body", ""),
                         expires_in_seconds=data.get("expiresInSeconds"),
                         attachments=[
-                            Attachment(
-                                content_type=attachment["contentType"],
-                                id=attachment["id"],
-                                size=attachment["size"],
-                                stored_filename=attachment["storedFilename"],
-                                custom_filename=attachment["customFilename"],
-                                width=attachment["width"],
-                                height=attachment["height"],
-                            )
+                            Attachment.create_from_receive_dict(attachment)
                             for attachment in data.get("attachments", [])
                         ],
                         group=group,

--- a/semaphore/message_sender.py
+++ b/semaphore/message_sender.py
@@ -20,8 +20,10 @@ import asyncio
 import json
 import logging
 import re
-from typing import Any, Dict
+from typing import Any, Dict, Optional, List
 
+
+from .attachment import Attachment
 from .exceptions import IDENTIFIABLE_SIGNALD_ERRORS, UnknownError
 from .message import Message
 from .reply import Reply
@@ -103,7 +105,7 @@ class MessageSender:
                 return False
             return False
 
-    async def send_message(self, receiver, body, attachments=None) -> bool:
+    async def send_message(self, receiver, body, attachments: Optional[List[Attachment]] = None) -> bool:
         """
         Send a message.
 
@@ -130,7 +132,7 @@ class MessageSender:
 
         # Add attachments to message.
         if attachments:
-            bot_message["attachments"] = attachments
+            bot_message["attachments"] = [attachment.to_send_dict() for attachment in attachments]
 
         return await self._send(bot_message)
 
@@ -172,7 +174,7 @@ class MessageSender:
 
             # Add attachments to message.
             if reply.attachments:
-                bot_message["attachments"] = reply.attachments
+                bot_message["attachments"] = [attachment.to_send_dict() for attachment in reply.attachments]
 
             # Add quote to message.
             if reply.quote:

--- a/semaphore/message_sender.py
+++ b/semaphore/message_sender.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 # Semaphore: A simple (rule-based) bot library for Signal Private Messenger.
-# Copyright (C) 2020-2021 Lazlo Westerhof <semaphore@lazlo.me>
+# Copyright (C) 2020-2022 Lazlo Westerhof <semaphore@lazlo.me>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -20,7 +20,7 @@ import asyncio
 import json
 import logging
 import re
-from typing import Any, Dict, Optional, List
+from typing import Any, Dict, List, Optional
 
 
 from .attachment import Attachment
@@ -105,7 +105,8 @@ class MessageSender:
                 return False
             return False
 
-    async def send_message(self, receiver, body, attachments: Optional[List[Attachment]] = None) -> bool:
+    async def send_message(self, receiver, body,
+                           attachments: Optional[List[Attachment]] = None) -> bool:
         """
         Send a message.
 
@@ -132,7 +133,9 @@ class MessageSender:
 
         # Add attachments to message.
         if attachments:
-            bot_message["attachments"] = [attachment.to_send_dict() for attachment in attachments]
+            bot_message["attachments"] = [
+                attachment.to_send_dict() for attachment in attachments
+            ]
 
         return await self._send(bot_message)
 
@@ -174,7 +177,9 @@ class MessageSender:
 
             # Add attachments to message.
             if reply.attachments:
-                bot_message["attachments"] = [attachment.to_send_dict() for attachment in reply.attachments]
+                bot_message["attachments"] = [
+                    attachment.to_send_dict() for attachment in reply.attachments
+                ]
 
             # Add quote to message.
             if reply.quote:

--- a/semaphore/reply.py
+++ b/semaphore/reply.py
@@ -17,6 +17,9 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """This module contains an object that represents a bot reply."""
 import attr
+from typing import List
+
+from .attachment import Attachment
 
 
 @attr.s(auto_attribs=True, frozen=True)
@@ -24,7 +27,7 @@ class Reply:
     """This object represents a Bot reply."""
 
     body: str
-    attachments: list = attr.ib(default=[])
+    attachments: List[Attachment] = attr.ib(default=[])
     quote: bool = attr.ib(default=False)
     reaction: bool = attr.ib(default=False)
     mark_read: bool = attr.ib(default=True)

--- a/semaphore/reply.py
+++ b/semaphore/reply.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 #
 # Semaphore: A simple (rule-based) bot library for Signal Private Messenger.
-# Copyright (C) 2020 Lazlo Westerhof <semaphore@lazlo.me>
+# Copyright (C) 2020-2022 Lazlo Westerhof <semaphore@lazlo.me>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -16,8 +16,9 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """This module contains an object that represents a bot reply."""
-import attr
 from typing import List
+
+import attr
 
 from .attachment import Attachment
 


### PR DESCRIPTION
The send and receive now works with Attachment list instead of a dict. This allows to get all the attachment data from a received message. It makes forwarding an attachment a much easier task. It also displays the original file name when forwarding a message.