### PR TITLE
Link previews

### DIFF
--- a/semaphore/__init__.py
+++ b/semaphore/__init__.py
@@ -27,6 +27,7 @@ from .group import Group
 from .groupV2 import GroupV2
 from .job import Job
 from .job_queue import JobQueue
+from .link_preview import LinkPreview
 from .message import Message
 from .message_receiver import MessageReceiver
 from .message_sender import MessageSender

--- a/semaphore/bot.py
+++ b/semaphore/bot.py
@@ -187,7 +187,8 @@ class Bot:
                 if message.data_message is not None:
                     await tg.spawn(self._match_message, message)
 
-    async def send_message(self, receiver, body, attachments=None) -> bool:
+    async def send_message(self, receiver, body, attachments=None,
+                           link_previews=None) -> bool:
         """
         Send a message.
 
@@ -197,7 +198,7 @@ class Bot:
         :return: Returns whether sending is successful
         :rtype: bool
         """
-        return await self._sender.send_message(receiver, body, attachments)
+        return await self._sender.send_message(receiver, body, attachments, link_previews)
 
     async def set_profile(self,
                           profile_name: str,

--- a/semaphore/bot.py
+++ b/semaphore/bot.py
@@ -195,6 +195,7 @@ class Bot:
         :param receiver:    The receiver of the message (uuid or number).
         :param body:        The body of the message.
         :param attachments: Optional attachments to the message.
+        :param link_previews: Optional link previews for the message.
         :return: Returns whether sending is successful
         :rtype: bool
         """

--- a/semaphore/data_message.py
+++ b/semaphore/data_message.py
@@ -24,6 +24,7 @@ from .attachment import Attachment
 from .group import Group
 from .groupV2 import GroupV2
 from .sticker import Sticker
+from .link_preview import LinkPreview
 
 
 @attr.s(auto_attribs=True, frozen=True)
@@ -37,3 +38,4 @@ class DataMessage:
     group: Optional[Group] = attr.ib(default=None)
     groupV2: Optional[GroupV2] = attr.ib(default=None)
     sticker: Optional[Sticker] = attr.ib(default=None)
+    previews: List[LinkPreview] = attr.ib(factory=list)

--- a/semaphore/data_message.py
+++ b/semaphore/data_message.py
@@ -23,8 +23,8 @@ import attr
 from .attachment import Attachment
 from .group import Group
 from .groupV2 import GroupV2
-from .sticker import Sticker
 from .link_preview import LinkPreview
+from .sticker import Sticker
 
 
 @attr.s(auto_attribs=True, frozen=True)

--- a/semaphore/link_preview.py
+++ b/semaphore/link_preview.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+#
+# Semaphore: A simple (rule-based) bot library for Signal Private Messenger.
+# Copyright (C) 2020-2022 Lazlo Westerhof <semaphore@lazlo.me>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""This module contains an object that represents a Signal message link preview."""
+import logging
+import re
+
+import attr
+
+from .attachment import Attachment
+
+
+@attr.s(auto_attribs=True)
+class LinkPreview:
+    """This object represents a Signal message link preview.
+
+    The attributes have a 1 to 1 correspondance to the signald JsonPreview class
+    https://signald.org/protocol/structures/v1/JsonPreview/
+    """
+
+    attachment: Attachment = attr.ib(default=None)
+    date: int = attr.ib(default=None)
+    description: str = attr.ib(default=None)
+    title: str = attr.ib(default=None)
+    url: str = attr.ib(default=None)
+
+    def to_send_dict(self) -> dict:
+        send_data = attr.asdict(self)
+        if self.attachment is not None:
+            send_data['attachment'] = self.attachment.to_send_dict()
+        return send_data
+
+    @staticmethod
+    def create_from_receive_dict(data: dict) -> 'LinkPreview':
+        processed_data = data.copy()
+        if 'attachment' in processed_data:
+            attachment = Attachment.create_from_receive_dict(data['attachment'])
+            processed_data['attachment'] = attachment
+
+        return LinkPreview(**processed_data)

--- a/semaphore/link_preview.py
+++ b/semaphore/link_preview.py
@@ -42,6 +42,9 @@ class LinkPreview:
         send_data = attr.asdict(self)
         if self.attachment is not None:
             send_data['attachment'] = self.attachment.to_send_dict()
+            # TODO Find a better fix than deleting the image because for now it's broken
+            # when sending
+            del send_data['attachment']
         return send_data
 
     @staticmethod
@@ -50,5 +53,8 @@ class LinkPreview:
         if 'attachment' in processed_data:
             attachment = Attachment.create_from_receive_dict(data['attachment'])
             processed_data['attachment'] = attachment
+            if attachment.stored_filename is None:
+                # Work around for bug in signald where the preview image is not downloaded
+                del processed_data['attachment']
 
         return LinkPreview(**processed_data)

--- a/semaphore/message_receiver.py
+++ b/semaphore/message_receiver.py
@@ -25,6 +25,7 @@ from .attachment import Attachment
 from .data_message import DataMessage
 from .group import Group
 from .groupV2 import GroupV2
+from .link_preview import LinkPreview
 from .message import Message
 from .message_sender import MessageSender
 from .socket import Socket
@@ -107,6 +108,10 @@ class MessageReceiver:
                         attachments=[
                             Attachment.create_from_receive_dict(attachment)
                             for attachment in data.get("attachments", [])
+                        ],
+                        previews=[
+                            LinkPreview.create_from_receive_dict(link_preview)
+                            for link_preview in data.get("previews", [])
                         ],
                         group=group,
                         groupV2=groupV2,

--- a/semaphore/message_sender.py
+++ b/semaphore/message_sender.py
@@ -28,6 +28,7 @@ from .exceptions import IDENTIFIABLE_SIGNALD_ERRORS, UnknownError
 from .message import Message
 from .reply import Reply
 from .socket import Socket
+from .link_preview import LinkPreview
 
 
 class MessageSender:
@@ -106,7 +107,8 @@ class MessageSender:
             return False
 
     async def send_message(self, receiver, body,
-                           attachments: Optional[List[Attachment]] = None) -> bool:
+                           attachments: Optional[List[Attachment]] = None,
+                           link_previews: Optional[List[LinkPreview]] = None) -> bool:
         """
         Send a message.
 
@@ -135,6 +137,11 @@ class MessageSender:
         if attachments:
             bot_message["attachments"] = [
                 attachment.to_send_dict() for attachment in attachments
+            ]
+
+        if link_previews:
+            bot_message["previews"] = [
+                link_preview.to_send_dict() for link_preview in link_previews
             ]
 
         return await self._send(bot_message)
@@ -179,6 +186,11 @@ class MessageSender:
             if reply.attachments:
                 bot_message["attachments"] = [
                     attachment.to_send_dict() for attachment in reply.attachments
+                ]
+
+            if reply.link_previews:
+                bot_message["previews"] = [
+                    link_preview.to_send_dict() for link_preview in reply.link_previews
                 ]
 
             # Add quote to message.

--- a/semaphore/message_sender.py
+++ b/semaphore/message_sender.py
@@ -25,10 +25,10 @@ from typing import Any, Dict, List, Optional
 
 from .attachment import Attachment
 from .exceptions import IDENTIFIABLE_SIGNALD_ERRORS, UnknownError
+from .link_preview import LinkPreview
 from .message import Message
 from .reply import Reply
 from .socket import Socket
-from .link_preview import LinkPreview
 
 
 class MessageSender:
@@ -115,6 +115,7 @@ class MessageSender:
         :param receiver:    The receiver of the message (uuid or number).
         :param body:        The body of the message.
         :param attachments: Optional attachments to the message.
+        :param link_previews: Optional link previews for the message.
 
         :return: Returns whether sending is successful.
         :rtype: bool

--- a/semaphore/reply.py
+++ b/semaphore/reply.py
@@ -21,6 +21,7 @@ from typing import List
 import attr
 
 from .attachment import Attachment
+from .link_preview import LinkPreview
 
 
 @attr.s(auto_attribs=True, frozen=True)
@@ -32,3 +33,4 @@ class Reply:
     quote: bool = attr.ib(default=False)
     reaction: bool = attr.ib(default=False)
     mark_read: bool = attr.ib(default=True)
+    link_previews: List[LinkPreview] = attr.ib(default=[])


### PR DESCRIPTION
Initial support for link previews.

It works well if sending or receiving without specifying the attachment attribute in the link preview.. However, when receiving with the attachment image, the image is not downloaded by signald. When sending one, the image overwrites all the information of the preview. So it ends up looking like a normal image attachment. I think this is something to raise on the signald repository. Not sure if you would like to offer this functionality as is now.